### PR TITLE
fix(TF-80): [dns] support bool default meta

### DIFF
--- a/client_2e2_test.go
+++ b/client_2e2_test.go
@@ -92,7 +92,7 @@ func TestNewClient(t *testing.T) {
 				*(&ResourceRecord{Enabled: true}).
 					SetContent(recType, recVal).
 					AddMeta(NewResourceMetaLatLong("1.1,2.2")).
-					AddMeta(NewResourceMetaDefault()).
+					AddMeta(NewResourceMetaDefault(true)).
 					AddMeta(NewResourceMetaAsn(1)),
 				*(&ResourceRecord{}).
 					SetContent(recType, recVal2).

--- a/client_dto.go
+++ b/client_dto.go
@@ -316,10 +316,10 @@ func NewResourceMetaContinents(continents ...string) ResourceMeta {
 }
 
 // NewResourceMetaDefault for default meta
-func NewResourceMetaDefault() ResourceMeta {
+func NewResourceMetaDefault(def bool) ResourceMeta {
 	return ResourceMeta{
 		name:  "default",
-		value: true,
+		value: def,
 	}
 }
 

--- a/client_dto_test.go
+++ b/client_dto_test.go
@@ -398,20 +398,31 @@ func TestNewResourceMetaContinents(t *testing.T) {
 func TestNewResourceMetaDefault(t *testing.T) {
 	tests := []struct {
 		name string
+		def  bool
 		want ResourceMeta
 	}{
 		{
 			name: "ok",
+			def:  true,
 			want: ResourceMeta{
 				name:     "default",
 				value:    true,
 				validErr: nil,
 			},
 		},
+		{
+			name: "false",
+			def:  false,
+			want: ResourceMeta{
+				name:     "default",
+				value:    false,
+				validErr: nil,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewResourceMetaDefault(); !reflect.DeepEqual(got, tt.want) {
+			if got := NewResourceMetaDefault(tt.def); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewResourceMetaDefault() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Add boolean support for default DNS record meta and align tests.